### PR TITLE
chore(adguard_home): use d unit in config to match AdGuard Home behavior

### DIFF
--- a/ansible/roles/adguard_home/templates/AdGuardHome.yaml.j2
+++ b/ansible/roles/adguard_home/templates/AdGuardHome.yaml.j2
@@ -10,7 +10,7 @@ http:
       - POST /dns-query/{ClientID}
     insecure_enabled: false
   address: 0.0.0.0:80
-  session_ttl: 720h
+  session_ttl: 30d
 users:
 {% for name, user in adguard_home.users.items() %}
   - name: {{ user.name }}
@@ -99,7 +99,7 @@ tls:
 querylog:
   dir_path: ""
   ignored: []
-  interval: 2160h
+  interval: 90d
   size_memory: 1000
   enabled: true
   ignored_enabled: false
@@ -107,7 +107,7 @@ querylog:
 statistics:
   dir_path: ""
   ignored: []
-  interval: 24h
+  interval: 1d
   enabled: true
   ignored_enabled: false
 filters:


### PR DESCRIPTION
Since [v0.107.76](https://github.com/AdguardTeam/AdGuardHome/releases/tag/v0.107.76), AdGuard Home uses the `d` (days) unit in its generated configuration (see #284).

This updates the configuration to match the format automatically written by the application, avoiding false-positive diffs in Ansible.